### PR TITLE
Update main.m

### DIFF
--- a/main.m
+++ b/main.m
@@ -1,6 +1,8 @@
 %=== Set directories to store video frames ===%
 workingDir = 'frames';
-if( exist(workingDir) )
+%=== exist with two arguments is better than single argument as it searches for all categories (file, dir, var, func, buitlin etc) ===%
+%=== when a single argument is given. So, its better to provide specific category as second argument to search for... ===%
+if( exist(workingDir, 'dir') )
     rmdir(workingDir, 's');
 end
 mkdir(workingDir);


### PR DESCRIPTION
`exists` function in matlab works better with 2 arguments in terms of **time** and simplicity.
If only one argument is provided, it starts searching for the object name in all categories which has a **considerable impact on the speed of execution**.
Providing the second argument (a category), limits the search in that category only and saves time.